### PR TITLE
Add support for null, boolean and detect empty arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Supported data types are
 - STRING
 - ARRAY
 - OBJECT
+- NULL
+- BOOLEAN
 
 # Usage
 - git clone

--- a/src/main/java/com/sgmarghade/AvroConverter.java
+++ b/src/main/java/com/sgmarghade/AvroConverter.java
@@ -31,6 +31,8 @@ public class AvroConverter {
     private static final String STRING = "string";
     private static final String RECORD = "record";
     private static final String FIELDS = "fields";
+    private static final String NULL = "null";
+    private static final String BOOLEAN = "boolean";
 
     private final ObjectMapper mapper;
 
@@ -106,6 +108,10 @@ public class AvroConverter {
                     final ObjectNode objectNode = mapper.createObjectNode();
                     objectNode.put(NAME, map.getKey());
 
+                    if (element == null) {
+                        throw new RuntimeException("Unable to guess at schema type for empty array");
+                    }
+
                     if (element.getNodeType() == JsonNodeType.NUMBER) {
                         objectNode.set(TYPE, mapper.createObjectNode().put(TYPE, ARRAY).put(ITEMS, (nextNode.isLong() ? "long" : "double")));
                         fields.add(objectNode);
@@ -125,6 +131,19 @@ public class AvroConverter {
                     node.put(NAME, map.getKey());
                     node.set(TYPE, mapper.createObjectNode().put(TYPE, RECORD).put(NAME, generateRandomNumber(map)).set(FIELDS, getFields(nextNode)));
                     fields.add(node);
+                    break;
+
+                case NULL:
+
+                    ObjectNode unionNullNode = mapper.createObjectNode();
+                    unionNullNode.put(NAME, map.getKey());
+                    unionNullNode.putArray(TYPE).add(NULL);
+                    fields.add(unionNullNode);
+                    break;
+
+                case BOOLEAN:
+
+                    fields.add(mapper.createObjectNode().put(NAME, map.getKey()).put(TYPE, BOOLEAN));
                     break;
 
                 default:

--- a/src/test/java/com/sgmarghade/AcroConverterTest.java
+++ b/src/test/java/com/sgmarghade/AcroConverterTest.java
@@ -41,11 +41,32 @@ public class AcroConverterTest {
         Assert.assertEquals("record",arrayNode.get(0).at("/type/type").asText());
     }
 
+    @Test
+    public void jsonWithNullValue() throws IOException {
+        String schema = converter.convert(TestHelper.getJsonWithNullField());
+        Assert.assertEquals(true, converter.validate(schema,TestHelper.getJsonWithNullField()));
+
+        final JsonNode schemaTree = mapper.readTree(schema);
+        final ArrayNode fields = (ArrayNode) schemaTree.at("/fields");
+        Assert.assertEquals("fieldThatsNull",fields.get(0).at("/name").asText());
+        Assert.assertEquals(true,fields.get(0).at("/type").isArray());
+        Assert.assertEquals("null",fields.get(0).at("/type/0").asText());
+    }
+
+    @Test
+    public void jsonWithBooleanValue() throws IOException {
+        String schema = converter.convert(TestHelper.getJsonWithBooleanField());
+        Assert.assertEquals(true, converter.validate(schema,TestHelper.getJsonWithBooleanField()));
+
+        final JsonNode schemaTree = mapper.readTree(schema);
+        final ArrayNode fields = (ArrayNode) schemaTree.at("/fields");
+        Assert.assertEquals("fieldThatsBoolean",fields.get(0).at("/name").asText());
+        Assert.assertEquals("boolean",fields.get(0).at("/type").asText());
+    }
+
     @Test(expected = RuntimeException.class)
-    public void invalidJsonWithNullValueShouldThrowException() throws IOException {
-        ObjectNode jsonNode = (ObjectNode) mapper.readTree(TestHelper.getJson());
-        jsonNode.set("dummyString", null);
-        converter.convert(jsonNode.toString());
+    public void jsonWithEmptyArray() throws IOException {
+        converter.convert(TestHelper.getJsonWithEmptyArray());
     }
 
     @Test

--- a/src/test/java/com/sgmarghade/TestHelper.java
+++ b/src/test/java/com/sgmarghade/TestHelper.java
@@ -97,4 +97,16 @@ public class TestHelper {
                 "\t}\n" +
                 "}";
     }
+
+    public static String getJsonWithNullField() {
+        return "{\"fieldThatsNull\":null}";
+    }
+
+    public static String getJsonWithBooleanField() {
+        return "{\"fieldThatsBoolean\":false}";
+    }
+
+    public static String getJsonWithEmptyArray() {
+        return "{\"emptyArray\":[]}";
+    }
 }


### PR DESCRIPTION
I had some content with all of the above, so was hoping the additions here would help. It handles a mocked JSON like:

```json
{
  "fieldThatsNull": null,
  "fieldThatsBoolean": false,
  "emptyArray": []
}
```

For the `null` case I have it generate a union type of only "null". At least with that, the user can massage the schema's union entry to include the actual type(s) they expect.