### PR TITLE
fix getting double entrys when lists are parsed into avroscheme

### DIFF
--- a/src/main/java/com/sgmarghade/AvroConverter.java
+++ b/src/main/java/com/sgmarghade/AvroConverter.java
@@ -122,7 +122,7 @@ public class AvroConverter {
                         objectNode.set(TYPE, mapper.createObjectNode().put(TYPE, ARRAY).set(ITEMS, mapper.createObjectNode()
                                 .put(TYPE, RECORD).put(NAME, generateRandomNumber(map)).set(FIELDS, getFields(element))));
                     }
-                    fields.add(objectNode);
+                    //fields.add(objectNode);
                     break;
 
                 case OBJECT:


### PR DESCRIPTION
If one parses the following json:
{list:["element"]}
the element showed twice in the output avro-scheme. 

Due to in _getFields()_ "_fields.add(objectNode);_" was called once too often i guess...